### PR TITLE
Make `bzl_library` targets availabe for downstream projects

### DIFF
--- a/uv/BUILD.bazel
+++ b/uv/BUILD.bazel
@@ -4,10 +4,16 @@ bzl_library(
     name = "pip",
     srcs = ["pip.bzl"],
     visibility = ["//visibility:public"],
+    deps = [
+        "//uv/private:pip",
+        "@bazel_skylib//lib:types",
+        "@bazel_skylib//rules:write_file",
+    ],
 )
 
 bzl_library(
     name = "venv",
     srcs = ["venv.bzl"],
     visibility = ["//visibility:public"],
+    deps = ["//uv/private:venv"],
 )

--- a/uv/private/BUILD.bazel
+++ b/uv/private/BUILD.bazel
@@ -10,11 +10,36 @@ exports_files([
 bzl_library(
     name = "pip",
     srcs = ["pip.bzl"],
-    visibility = ["//multitool:__subpackages__"],
+    visibility = [
+        "//multitool:__subpackages__",
+        "//uv:__pkg__",
+    ],
+    deps = [
+        ":interpreter_path",
+        ":transition_to_target",
+        "@rules_python//python:defs_bzl",
+    ],
 )
 
 bzl_library(
     name = "venv",
     srcs = ["venv.bzl"],
-    visibility = ["//multitool:__subpackages__"],
+    visibility = [
+        "//multitool:__subpackages__",
+        "//uv:__pkg__",
+    ],
+    deps = [
+        ":interpreter_path",
+        ":transition_to_target",
+    ],
+)
+
+bzl_library(
+    name = "interpreter_path",
+    srcs = ["interpreter_path.bzl"],
+)
+
+bzl_library(
+    name = "transition_to_target",
+    srcs = ["transition_to_target.bzl"],
 )


### PR DESCRIPTION
This makes it possible to use `@rules_uv//uv:pip` downstream `bzl_library` targets